### PR TITLE
lzq_commit

### DIFF
--- a/src/command/CommitCommand.java
+++ b/src/command/CommitCommand.java
@@ -15,18 +15,20 @@ import java.util.logging.Logger;
 public class CommitCommand implements ICommand{
     private final Repository repository;
     private final String command;
-    private final Logger logger = Logger.getLogger(AddCommand.class.getName());
+    private final Logger logger = Logger.getLogger(CommitCommand.class.getName());
+
 
     public CommitCommand(Repository repository, String command) {
         this.repository = repository;
         this.command = command;
     }
 
+    private static final String COMMIT_MESSAGE_FLAG = "-m";
     @Override
     public ViewResponseEntity execute() {
         String[] commandSplits = repository.commandParseSplit(command);
         if (commandSplits.length == 4) {
-            if (commandSplits[2].equals("-m")) {
+            if (commandSplits[2].equals(COMMIT_MESSAGE_FLAG)) {
                 logger.info("commit message: " + commandSplits[3]);
                 return clearStageAndCommit(commandSplits[3], "");
             }
@@ -46,6 +48,7 @@ public class CommitCommand implements ICommand{
         Date date = new Date();
         String obj = message + date;
         String newCommitId = PersistanceUtils.sha1(obj);
+        logger.info("Entering clearStageAndCommit with message: " + message + " and secondParentId: " + secondParentId);
         // how we get the lastest commitId? -> current branch head point at it
         String currentCommitId = repository.getCurrentLocalBranchHeadId();
         Commit currentCommit = repository.getCurrentLocalBranchHead();


### PR DESCRIPTION
我根据先前提出的issue内容作了如下修改：
1.我将 command/CommitCommand.java 中的 "-m" 、engine/Repository.java 中的 "ref: " 和 " "这些硬编码的字符串定义为常量,可以提高可读性和可维护性
2.engine/Repository.java中的getCurrentFilesToContentMapHelper 方法中存在代码重复：处理目录名称和文件名称的逻辑重复，我将公共逻辑提取到单独的方法中以减少重复。
3.我在command/CommitCommand.java的createCommitAndClearStage方法中添加了logger.info("Entering clearStageAndCommit with message: " + message + "and secondParentId: " + secondParentId);的日志记录, 包括方法的进入/退出点和参数值，可以便于调试
4.CommitCommand 类中的日志记录器初始化时使用了另一个类 ( AddCommand ) 的名称，我修改了正确的类名初始化日志记录器, 修复日志初始化的问题。
5.engine/Engine.java中init/add/commit等每个命令的处理逻辑都类似，存在大量重复代码，我将命令处理逻辑提取到一个单独的方法commandResponse 中，减少重复代码。
6.engine/Engine.java中commandResponse方法中命令解析逻辑只简单地使用 split(" ") ，没有处理包含空格的文件名等情况，我使用parseCommand 方法实现解析一个包含空格和可能的双引号的命令字符串。
7.command/AddCommand.java中addSingleFile方法的代码中存在一些复杂的逻辑，我将它们分成两个小方法了handleFileInStage和handleRemovedFile